### PR TITLE
Fix optional children annotations to match what ReasonReact requires.

### DIFF
--- a/src/Antd_Form.re
+++ b/src/Antd_Form.re
@@ -19,7 +19,7 @@ external makePropsForm:
     ~hideRequiredMark: bool=?,
     ~wrapperCol: Antd_Grid.Col.props=?,
     ~colon: bool=?,
-    ~children: React.element,
+    ~children: React.element=?,
     unit
   ) =>
   _ =
@@ -40,7 +40,7 @@ let make =
       ~hideRequiredMark: option(bool)=?,
       ~wrapperCol: option(Antd_Grid.Col.props)=?,
       ~colon: option(bool)=?,
-      ~children: React.element=?,
+      ~children: option(React.element)=?,
     ) =>
   React.createElement(
     reactComponent,
@@ -59,7 +59,7 @@ let make =
       ~hideRequiredMark?,
       ~wrapperCol?,
       ~colon?,
-      ~children,
+      ~children?,
       (),
     ),
   );
@@ -85,7 +85,7 @@ module Item = {
       ~required: bool=?,
       ~style: ReactDOMRe.Style.t=?,
       ~colon: bool=?,
-      ~children: React.element
+      ~children: React.element=?
     ) =>
     _ =
     "";
@@ -110,7 +110,7 @@ module Item = {
         ~required: option(bool)=?,
         ~style: option(ReactDOMRe.Style.t)=?,
         ~colon: option(bool)=?,
-        ~children: React.element=?,
+        ~children: option(React.element)=?,
       ) =>
     React.createElement(
       reactComponent,
@@ -129,7 +129,7 @@ module Item = {
         ~required?,
         ~style?,
         ~colon?,
-        ~children,
+        ~children?,
       ),
     );
 };


### PR DESCRIPTION
BuckleScript 7.1.0 raises errors if the explicit `option` wrapping is not provided.

This fixes #11: Can't run with BuckleScript 7.1.0.